### PR TITLE
Adds Caching to Kafka producer

### DIFF
--- a/contribs/build.gradle
+++ b/contribs/build.gradle
@@ -17,7 +17,7 @@ dependencies {
 	compile "io.swagger:swagger-jaxrs:${revSwagger}"
 
 	compile "org.apache.kafka:kafka-clients:2.2.0"
-
+	compile "com.google.guava:guava:${revGuava}"
 	testCompile "org.eclipse.jetty:jetty-server:${revJetteyServer}"
 	testCompile "org.eclipse.jetty:jetty-servlet:${revJettyServlet}"
 }

--- a/contribs/src/main/java/com/netflix/conductor/contribs/kafka/KafkaProducerManager.java
+++ b/contribs/src/main/java/com/netflix/conductor/contribs/kafka/KafkaProducerManager.java
@@ -1,33 +1,72 @@
 package com.netflix.conductor.contribs.kafka;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.RemovalListener;
+import com.google.common.cache.RemovalNotification;
 import com.netflix.conductor.core.config.Configuration;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.clients.producer.ProducerConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Objects;
 import java.util.Properties;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
 
 public class KafkaProducerManager {
 
 	public static final String KAFKA_PUBLISH_REQUEST_TIMEOUT_MS = "kafka.publish.request.timeout.ms";
 	public static final String STRING_SERIALIZER = "org.apache.kafka.common.serialization.StringSerializer";
 	public static final String DEFAULT_REQUEST_TIMEOUT = "100";
+	private static final String KAFKA_PRODUCER_CACHE_TIME_IN_MILLIS = "kafka.publish.producer.cache.time.ms" ;
+	private static final int DEFAULT_CACHE_SIZE = 10;
+	private static final String KAFKA_PRODUCER_CACHE_SIZE = "kafka.publish.producer.cache.size";
+	private static final int DEFAULT_CACHE_TIME_IN_MILLIS = 120000;
+
+	private static final Logger logger = LoggerFactory.getLogger(KafkaProducerManager.class);
+
+	public static final RemovalListener<Properties, Producer> LISTENER = new RemovalListener<Properties, Producer>() {
+		@Override
+		public void onRemoval(RemovalNotification<Properties, Producer> notification) {
+			notification.getValue().close();
+			logger.info("Closed producer for {}",notification.getKey());
+		}
+	};
+
 
 	public final String requestTimeoutConfig;
+	private Cache<Properties, Producer> kafkaProducerCache;
 
 	public KafkaProducerManager(Configuration configuration) {
 		this.requestTimeoutConfig = configuration.getProperty(KAFKA_PUBLISH_REQUEST_TIMEOUT_MS, DEFAULT_REQUEST_TIMEOUT);
+		int cacheSize = configuration.getIntProperty(KAFKA_PRODUCER_CACHE_SIZE, DEFAULT_CACHE_SIZE);
+		int cacheTimeInMs = configuration.getIntProperty(KAFKA_PRODUCER_CACHE_TIME_IN_MILLIS, DEFAULT_CACHE_TIME_IN_MILLIS);
+		this.kafkaProducerCache = CacheBuilder.newBuilder().removalListener(LISTENER)
+				.maximumSize(cacheSize).expireAfterAccess(cacheTimeInMs, TimeUnit.MILLISECONDS)
+				.build();
 	}
 
 
 	public Producer getProducer(KafkaPublishTask.Input input) {
 
 		Properties configProperties = getProducerProperties(input);
-		Producer producer = new KafkaProducer<String, String>(configProperties);
-		return producer;
 
+		return getFromCache(configProperties, () -> new KafkaProducer(configProperties));
+
+	}
+
+	@VisibleForTesting
+	Producer getFromCache(Properties configProperties, Callable<Producer> createProducerCallable) {
+		try {
+			return kafkaProducerCache.get(configProperties, createProducerCallable);
+		} catch (ExecutionException e) {
+			throw new RuntimeException(e);
+		}
 	}
 
 	@VisibleForTesting

--- a/contribs/src/main/java/com/netflix/conductor/contribs/kafka/KafkaPublishTask.java
+++ b/contribs/src/main/java/com/netflix/conductor/contribs/kafka/KafkaPublishTask.java
@@ -145,7 +145,6 @@ public class KafkaPublishTask extends WorkflowSystemTask {
 				null, key, om.writeValueAsString(input.getValue()), headers);
 
 		Future send = producer.send(rec);
-		producer.close();
 
 		long timeTakenToPublish = Instant.now().toEpochMilli() - startPublishingEpochMillis;
 

--- a/versionsOfDependencies.gradle
+++ b/versionsOfDependencies.gradle
@@ -18,6 +18,7 @@ ext {
     revFlywayCore ='4.0.3'
     revGrpc = '1.14.+'
     revGuavaRetrying = '2.0.0'
+    revGuava = '28.0-jre'
     revGuice = '4.1.0'
     revGuiceMultiBindings = '4.1.0'
     revGuiceServlet = '4.1.0'


### PR DESCRIPTION
Creation of Kafka producer is consuming time. In local, it takes around 100 ms. To support 1 lakh rpm by CMS we would need to optimize it. I have cached the producer object and noticed that the time taken reduces ~5ms. 