### PR TITLE
Loopover task output miss match fix.

### DIFF
--- a/common/src/main/java/com/netflix/conductor/common/metadata/workflow/WorkflowDef.java
+++ b/common/src/main/java/com/netflix/conductor/common/metadata/workflow/WorkflowDef.java
@@ -245,7 +245,8 @@ public class WorkflowDef extends Auditable {
 				 return nextTask;
 			 }
 
-			 if(task.getTaskReferenceName().equals(taskReferenceName) || task.has(taskReferenceName)){
+			 if(task.getTaskReferenceName().equals(taskReferenceName) || (
+			 		task.has(taskReferenceName) && !task.getType().equals(TaskType.TASK_TYPE_DO_WHILE))) {
 				 break;
 			 }
 		}

--- a/core/src/main/java/com/netflix/conductor/core/execution/tasks/DoWhile.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/tasks/DoWhile.java
@@ -81,7 +81,8 @@ public class DoWhile extends WorkflowSystemTask {
 		}
 		task.getOutputData().put(String.valueOf(task.getIteration()), output);
 		if (hasFailures) {
-			return markLoopTaskFailed(task, failureReason.toString());
+			logger.debug("taskid {} failed in {} iteration",task.getTaskId(), task.getIteration() + 1);
+			return updateLoopTask(task, Status.FAILED, failureReason.toString());
 		} else if (!allDone) {
 			return false;
 		}
@@ -92,13 +93,14 @@ public class DoWhile extends WorkflowSystemTask {
 			if (shouldContinue) {
 				return scheduleLoopTasks(task, workflow, workflowExecutor);
 			} else {
-				return markLoopTaskSuccess(task);
+				logger.debug("taskid {} took {} iterations to complete",task.getTaskId(), task.getIteration() + 1);
+				return markLoopTaskSuccess(task, workflow, workflowExecutor);
 			}
 		} catch (ScriptException e) {
 			String message = String.format("Unable to evaluate condition %s , exception %s", task.getWorkflowTask().getLoopCondition(), e.getMessage());
 			logger.error(message);
-			logger.error("Marking task {} failed.", task.getTaskId());
-			return markLoopTaskFailed(task, message);
+			logger.error("Marking task {} failed with error.", task.getTaskId());
+			return updateLoopTask(task, Status.FAILED_WITH_TERMINAL_ERROR, message);
 		}
 	}
 
@@ -111,15 +113,15 @@ public class DoWhile extends WorkflowSystemTask {
 		return true; // Return true even though status not changed. Iteration has to be updated in execution DAO.
 	}
 
-	boolean markLoopTaskFailed(Task task, String failureReason) {
+	boolean updateLoopTask(Task task,Status status, String failureReason) {
 		task.setReasonForIncompletion(failureReason);
-		task.setStatus(Status.FAILED);
-		logger.debug("taskid {} failed in {} iteration",task.getTaskId(), task.getIteration() + 1);
+		task.setStatus(status);
 		return true;
 	}
 
-	boolean markLoopTaskSuccess(Task task) {
+	boolean markLoopTaskSuccess(Task task, Workflow workflow, WorkflowExecutor workflowExecutor) {
 		logger.debug("taskid {} took {} iterations to complete",task.getTaskId(), task.getIteration() + 1);
+		workflowExecutor.removeLoopOverTasks(task, workflow);
 		task.setStatus(Status.COMPLETED);
 		return true;
 	}


### PR DESCRIPTION
Issue is, do while task is getting updated after any of loopover task comes into terminal state as a part of decide function. Now when any of loopover task will be updated it will update the redis with the result. So we will have two result for same task with same seq number and taskDetails.js will sort based on seq number and task details table will have keys as seq number so actual task output will be ignored. So this PR will remove the old task details from redis once do while task will come in terminal state.